### PR TITLE
Update Java version to 17

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -18,7 +18,7 @@ jobs:
       - uses: actions/setup-java@v1
         with:
           distribution: 'temurin'
-          java-version: '11'
+          java-version: '17'
           cache: 'gradle'
 
       - name: "Determine next tag"


### PR DESCRIPTION
Fixes build problems introduced with the bump of the Java version used in NewPipe (TeamNewPipe/NewPipe#10035).
Closes #4