### PR TITLE
Bump Github actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,13 +9,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
         with:
           fetch-depth: '0'
           ref: 'dev'
           token: ${{secrets.ACCESS_TOKEN}}
 
-      - uses: actions/setup-java@v1
+      - uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/