### PR TITLE
Bump Github actions

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,13 +9,13 @@ jobs:
   release:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
           ref: 'dev'
           token: ${{secrets.ACCESS_TOKEN}}
 
-      - uses: actions/setup-java@v3
+      - uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: '17'


### PR DESCRIPTION
Github drops support to Node JS 16 in Github actions -> https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
This PR:
- bump checkout to v4 -> https://github.com/actions/checkout/releases/tag/v4.0.0
- bump setup-java to v4 ->https://github.com/actions/setup-java/releases/tag/v4.0.0

I have already made these changes in other repositories without break changes