### PR TITLE
Replace gh actions for signing and releasing

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -59,14 +59,15 @@ jobs:
 
       - name: "Sign release"
         if: ${{ env.new_commit == 'true' }}
-        uses: r0adkll/sign-android-release@v1
+        uses: ilharp/sign-android-release@v1
         id: sign_app
         with:
-          releaseDirectory: app/build/outputs/apk/release
-          signingKeyBase64: ${{ secrets.SIGNING_KEY }}
-          alias: ${{ secrets.ALIAS }}
+          releaseDir: app/build/outputs/apk/release
+          signingKey: ${{ secrets.SIGNING_KEY }}
+          keyAlias: ${{ secrets.ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
           keyPassword: ${{ secrets.KEY_PASSWORD }}
+          buildToolsVersion: 33.0.0
 
       - name: "Create GitHub release"
         if: ${{ env.new_commit == 'true' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,24 +67,12 @@ jobs:
           keyPassword: ${{ secrets.KEY_PASSWORD }}
           buildToolsVersion: 33.0.0
 
-      - name: "Create GitHub release"
+      - name: "Create GitHub release with APK"
         if: ${{ env.new_commit == 'true' }}
-        uses: actions/create-release@v1
+        uses: softprops/action-gh-release@v1
         id: create_release
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ steps.tagger.outputs.new_tag }}
-          release_name: ${{ steps.tagger.outputs.new_tag }}
-          commitish: dev
-
-      - name: "Upload release APK"
-        if: ${{ env.new_commit == 'true' }}
-        uses: actions/upload-release-asset@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        with:
-          upload_url: ${{ steps.create_release.outputs.upload_url }}
-          asset_path: ${{ steps.sign_app.outputs.signedReleaseFile }}
-          asset_name: NewPipe_${{steps.tagger.outputs.new_tag}}.apk
-          asset_content_type: application/zip
+          target_commitish: dev
+          files: |
+            ${{steps.sign_app.outputs.signedFile}}/NewPipe_${{steps.tagger.outputs.new_tag}}.apk

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -41,8 +41,10 @@ jobs:
 
       - name: "Check for new commits"
         run : |
-            echo "New commits found"
-            echo "new_commit=true" >> $GITHUB_ENV
+          if [[ $(git log --since=1.days) ]]; then
+          echo "New commits found"
+          echo "new_commit=true" >> $GITHUB_ENV
+          fi 
 
       - name: "Tag commit"
         if: ${{ env.new_commit == 'true' }}
@@ -81,6 +83,5 @@ jobs:
         with:
           tag_name: ${{ steps.tagger.outputs.new_tag }}
           target_commitish: dev
-          draft: true
           files: |
             ${{steps.rename_apk.outputs.apkFile}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,12 +39,7 @@ jobs:
       - name: "Build release apk"
         run: ./gradlew assembleRelease --stacktrace -DpackageSuffix=nightly
 
-      - name: "Check for new commits"
-        run : |
-          if [[ $(git log --since=1.days) ]]; then
-            echo "New commits found"
-            echo "new_commit=true" >> $GITHUB_ENV
-          fi 
+
 
       - name: "Tag commit"
         if: ${{ env.new_commit == 'true' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -39,7 +39,10 @@ jobs:
       - name: "Build release apk"
         run: ./gradlew assembleRelease --stacktrace -DpackageSuffix=nightly
 
-
+      - name: "Check for new commits"
+        run : |
+            echo "New commits found"
+            echo "new_commit=true" >> $GITHUB_ENV
 
       - name: "Tag commit"
         if: ${{ env.new_commit == 'true' }}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -67,6 +67,13 @@ jobs:
           keyPassword: ${{ secrets.KEY_PASSWORD }}
           buildToolsVersion: 33.0.0
 
+      - name: "Rename apk"
+        if: ${{ env.new_commit == 'true' }}
+        id: rename_apk
+        run: |
+          mv ${{steps.sign_app.outputs.signedFile}} app/build/outputs/apk/release/NewPipe_${{steps.tagger.outputs.new_tag}}.apk
+          echo "::set-output name=apkFile::app/build/outputs/apk/release/NewPipe_${{steps.tagger.outputs.new_tag}}.apk"
+
       - name: "Create GitHub release with APK"
         if: ${{ env.new_commit == 'true' }}
         uses: softprops/action-gh-release@v1
@@ -76,4 +83,4 @@ jobs:
           target_commitish: dev
           draft: true
           files: |
-            ${{steps.sign_app.outputs.signedFile}}
+            ${{steps.rename_apk.outputs.apkFile}}

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -42,8 +42,8 @@ jobs:
       - name: "Check for new commits"
         run : |
           if [[ $(git log --since=1.days) ]]; then
-          echo "New commits found"
-          echo "new_commit=true" >> $GITHUB_ENV
+            echo "New commits found"
+            echo "new_commit=true" >> $GITHUB_ENV
           fi 
 
       - name: "Tag commit"

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -74,5 +74,6 @@ jobs:
         with:
           tag_name: ${{ steps.tagger.outputs.new_tag }}
           target_commitish: dev
+          draft: true
           files: |
-            ${{steps.sign_app.outputs.signedFile}}/NewPipe_${{steps.tagger.outputs.new_tag}}.apk
+            ${{steps.sign_app.outputs.signedFile}}


### PR DESCRIPTION
Replace 
- r0adkll/sign-android-release with ilharp/sign-android-release
- actions/create-release and actions/upload-release-asset with softprops/action-gh-release

roadkll is not maintained and the other 2 are archived

I ran it once successfully, which created https://github.com/TeamNewPipe/NewPipe-nightly/releases/tag/nightly-101