### PR TITLE
Create workflow to delete old releases

### DIFF
--- a/.github/workflows/delete-old-releases.yml
+++ b/.github/workflows/delete-old-releases.yml
@@ -1,0 +1,37 @@
+name: Delete old releases
+
+on:
+  schedule: 
+    - cron: '15 23 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  cleanup:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      # Related: https://github.com/actions/checkout/issues/1471
+      - name: Fetch tags
+        run: git fetch --prune --unshallow --tags
+
+      - name: Delete old releases if required
+        run: |
+          # Keep last 50 releases
+          tags_to_delete=($(git tag --sort=-v:refname | grep nightly- | tail -n+50))
+
+          if (( ${#tags_to_delete[@]} )); then
+            echo "Will delete ${tags_to_delete[*]}"
+            for tag_to_delete in "${tags_to_delete[@]}"
+            do
+               echo "Deleting $tag_to_delete"
+               git push -v --delete origin "$tag_to_delete"
+               # Delete GitHub release if present
+               gh release delete -y "$tag_to_delete" || true
+            done
+          fi
+        env:
+          GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
Fixes #21

Only keeps the last 50 releases (equals 7 weeks of building a nightly every day - this equals roughly a year worth of releases) and deletes all that are older.

Example executions in my fork:
* [Deleting all outdated releases](https://github.com/litetex/NewPipe-nightly/actions/runs/11672686207/job/32501832234)
* [Nothing to delete](https://github.com/litetex/NewPipe-nightly/actions/runs/11672715901/job/32501924530)
* [Deleting a single outdated release](https://github.com/litetex/NewPipe-nightly/actions/runs/11672786355/job/32502140069)
