### PR TITLE
Rework repo handling

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -22,6 +22,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
+          # This is required for checking out the tags, so that the next tag can be computed
           fetch-depth: '0'
       
       - uses: actions/checkout@v4

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -14,12 +14,11 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-
 jobs:
   release:
     runs-on: ubuntu-latest
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -28,6 +28,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           repository: 'TeamNewPipe/NewPipe'
+          ref: 'dev'
           path: workdir
       
       - name: Check if release is required

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -7,8 +7,15 @@ on:
     inputs:
       ignore_commits_force_release:
         type: boolean
-        description: 'Ignore (new) commits and force a release'
+        description: 'Do not check for new commits / Force new release'
         default: false
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
 
 jobs:
   release:
@@ -17,16 +24,51 @@ jobs:
       - uses: actions/checkout@v4
         with:
           fetch-depth: '0'
-          ref: 'dev'
-          token: ${{secrets.ACCESS_TOKEN}}
+      
+      - uses: actions/checkout@v4
+        with:
+          repository: 'TeamNewPipe/NewPipe'
+          path: workdir
+      
+      - name: Check if release is required
+        id: release_check
+        run: |
+          last_built_commit=$(cat last-built-commit.txt || echo "")
+          current_commit=$(cd workdir && git rev-parse HEAD)
 
+          echo "Last built commit: $last_built_commit"
+          echo "Current commit: $current_commit"
+
+          do_release=false
+
+          if [[ "${{ inputs.ignore_commits_force_release }}" == "true" ]]; then
+            echo "Ignoring commits - Forcing release"
+            do_release=true
+          elif [[ "$last_built_commit" != "$current_commit" ]]; then
+            echo "Commits differ - Will do a release"
+            do_release=true
+          fi
+
+          if [[ "$do_release" != "true" ]]; then
+            echo "No release required: Nothing changed"
+            exit 0
+          fi
+
+          echo "Saving current commit to file"
+          echo "$current_commit" > last-built-commit.txt
+
+          echo "do_release=true" >> $GITHUB_ENV
+          echo "current_commit=$current_commit" >> $GITHUB_OUTPUT
+          
       - uses: actions/setup-java@v4
+        if: ${{ env.do_release == 'true' }}
         with:
           distribution: 'temurin'
           java-version: '21'
           cache: 'gradle'
 
-      - name: "Determine next tag"
+      - name: Determine next tag
+        if: ${{ env.do_release == 'true' }}
         id: tagger
         run: |
           TAG="$(git tag --sort=-v:refname | grep nightly- | head -n 1)"
@@ -37,23 +79,9 @@ jobs:
           echo "new_tag=${NEW_TAG}" >> $GITHUB_OUTPUT
           echo "new_version_id=${INCREMENT}" >> $GITHUB_OUTPUT
 
-      - name: "Pull upstream"
-        run: |
-          git remote add upstream https://github.com/TeamNewPipe/NewPipe.git
-          git pull upstream dev
-
-      - name: "Checking if a release needs to be done"
-        run : |
-          if [[ "${{ inputs.ignore_commits_force_release }}" == "true" ]]; then
-            echo "Ignoring commits - Forcing release"
-            echo "do_release=true" >> $GITHUB_ENV
-          elif [[ "$(git log --since=1.days)" ]]; then
-            echo "New commits found - Will do a release"
-            echo "do_release=true" >> $GITHUB_ENV
-          fi 
-
-      - name: "Build release apk"
+      - name: Build release apk
         if: ${{ env.do_release == 'true' }}
+        working-directory: workdir
         run: >-
           ./gradlew assembleRelease
           --stacktrace
@@ -61,23 +89,16 @@ jobs:
           -DversionNameSuffix=-${{ steps.tagger.outputs.new_version_id }}-$(date -u '+%Y%m%d%H%M')
           -DversionCodeOverride=${{ steps.tagger.outputs.new_version_id }}
 
-      - name: "Tag commit"
+      - name: Tag commit
         if: ${{ env.do_release == 'true' }}
         run: git tag "${{ steps.tagger.outputs.new_tag }}"
 
-      - name: "Push to nightly repo"
-        if: ${{ env.do_release == 'true' }}
-        uses: ad-m/github-push-action@v0.8.0
-        with:
-          github_token: ${{secrets.ACCESS_TOKEN}}
-          branch: dev
-
-      - name: "Sign release"
+      - name: Sign release
         if: ${{ env.do_release == 'true' }}
         uses: ilharp/sign-android-release@d4c98d58d708ca2d2e6a3469b189a5c8260f2896
         id: sign_app
         with:
-          releaseDir: app/build/outputs/apk/release
+          releaseDir: workdir/app/build/outputs/apk/release
           signingKey: ${{ secrets.SIGNING_KEY }}
           keyAlias: ${{ secrets.ALIAS }}
           keyStorePassword: ${{ secrets.KEY_STORE_PASSWORD }}
@@ -86,19 +107,33 @@ jobs:
           # Changelogs can be found at https://developer.android.com/tools/releases/platform-tools
           buildToolsVersion: 35.0.1
 
-      - name: "Rename apk"
+      - name: Rename apk
         if: ${{ env.do_release == 'true' }}
         id: rename_apk
         run: |
-          mv "${{steps.sign_app.outputs.signedFile}}" "app/build/outputs/apk/release/NewPipe_${{steps.tagger.outputs.new_tag}}.apk"
-          echo "apkFile=app/build/outputs/apk/release/NewPipe_${{steps.tagger.outputs.new_tag}}.apk" >> $GITHUB_OUTPUT
+          mv "${{steps.sign_app.outputs.signedFile}}" "workdir/app/build/outputs/apk/release/NewPipe_${{steps.tagger.outputs.new_tag}}.apk"
+          echo "apkFile=workdir/app/build/outputs/apk/release/NewPipe_${{steps.tagger.outputs.new_tag}}.apk" >> $GITHUB_OUTPUT
 
-      - name: "Create GitHub release with APK"
+      - name: Create GitHub release with APK
         if: ${{ env.do_release == 'true' }}
         uses: softprops/action-gh-release@v2
-        id: create_release
         with:
           tag_name: ${{ steps.tagger.outputs.new_tag }}
-          target_commitish: dev
+          body: |
+            Build of [``${{ steps.release_check.outputs.current_commit }}``](https://github.com/TeamNewPipe/NewPipe/commit/${{ steps.release_check.outputs.current_commit }})
           files: |
             ${{steps.rename_apk.outputs.apkFile}}
+      
+      - name: Commit changed files
+        if: ${{ env.do_release == 'true' }}
+        run: |
+          echo "Removing workdir"
+          rm -rf workdir
+
+          echo "Configuring git"
+          git config --global user.email "actions@github.com"
+          git config --global user.name "GitHub Actions"
+
+          echo "Committing changed tracking files"
+          git add -A || true
+          git commit -m "Updated tracking files" && git push || true

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+*.apk
+workdir/


### PR DESCRIPTION
* App/NewPipe repo/branch no longer needs to be attached
  * The overall repo will therefore be smaller
  * One downside: The tags are no longer assoicated directly with the App/NewPipe repo however there is now a description for that inside the release
* The access token is no longer required

Fixes #27

Example can be found here:
* https://github.com/litetex/NewPipe-nightly/releases/tag/nightly-2
* The branch where this was built: https://github.com/litetex/NewPipe-nightly/tree/rework
* Commit that updated the tracking files: https://github.com/litetex/NewPipe-nightly/commit/1f16d24664f16b8d649609f7c7a6ea3d339dd216
* Action run when something changed/that built the above release: https://github.com/litetex/NewPipe-nightly/actions/runs/12967787465/job/36170044858
* Action run when nothing changed: https://github.com/litetex/NewPipe-nightly/actions/runs/12967880807/job/36170250814